### PR TITLE
Re-export `Prim.Coerce.Coercible`

### DIFF
--- a/src/Safe/Coerce.purs
+++ b/src/Safe/Coerce.purs
@@ -1,6 +1,6 @@
-
 module Safe.Coerce
-  ( coerce
+  ( module Prim.Coerce
+  , coerce
   ) where
 
 import Prim.Coerce (class Coercible)


### PR DESCRIPTION
Being able to import `Coercible` from `Safe.Coerce` instead of `Prim.Coerce` offers similar ergonomics than the typelevel prelude regarding the `Prim.*` modules.